### PR TITLE
Update AbstractCrudController.php autocomplete to process fields

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -461,12 +461,11 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
         /** @var CrudControllerInterface $controller */
         $controller = $this->container->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext[EA::CRUD_CONTROLLER_FQCN], Action::INDEX, $context->getRequest());
-        /** @var FieldDto|null $field */
         $fields = FieldCollection::new($controller->configureFields($autocompleteContext['originatingPage']));
         $this->container->get(EntityFactory::class)->processFields($context->getEntity(), $fields);
+        /** @var FieldDto|null $field */
+        $field = $fields->getByProperty($autocompleteContext['propertyName']);
         /** @var \Closure|null $queryBuilderCallable */
-        $field  = $fields->getByProperty($autocompleteContext['propertyName']);
-
         $queryBuilderCallable = $field?->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE);
 
         if (null !== $queryBuilderCallable) {

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -470,7 +470,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             Action::INDEX,
             $context->getRequest()
         );
-        $entityFqcn = $controller->getEntityFqcn();
+        $entityFqcn = $controller::getEntityFqcn();
         $entityDto = new EntityDto(
             $entityFqcn,
             $this->container->get(EntityFactory::class)->getEntityMetadata($entityFqcn)

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -462,8 +462,11 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         /** @var CrudControllerInterface $controller */
         $controller = $this->container->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext[EA::CRUD_CONTROLLER_FQCN], Action::INDEX, $context->getRequest());
         /** @var FieldDto|null $field */
-        $field = FieldCollection::new($controller->configureFields($autocompleteContext['originatingPage']))->getByProperty($autocompleteContext['propertyName']);
+        $fields = FieldCollection::new($controller->configureFields($autocompleteContext['originatingPage']));
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), $fields);
         /** @var \Closure|null $queryBuilderCallable */
+        $field  = $fields->getByProperty($autocompleteContext['propertyName']);
+
         $queryBuilderCallable = $field?->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE);
 
         if (null !== $queryBuilderCallable) {

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -455,14 +455,28 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function autocomplete(AdminContext $context): JsonResponse
     {
-        $queryBuilder = $this->createIndexQueryBuilder($context->getSearch(), $context->getEntity(), FieldCollection::new([]), FilterCollection::new());
+        $queryBuilder = $this->createIndexQueryBuilder(
+            $context->getSearch(),
+            $context->getEntity(),
+            FieldCollection::new([]),
+            FilterCollection::new()
+        );
 
         $autocompleteContext = $context->getRequest()->get(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT);
 
         /** @var CrudControllerInterface $controller */
-        $controller = $this->container->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext[EA::CRUD_CONTROLLER_FQCN], Action::INDEX, $context->getRequest());
+        $controller = $this->container->get(ControllerFactory::class)->getCrudControllerInstance(
+            $autocompleteContext[EA::CRUD_CONTROLLER_FQCN],
+            Action::INDEX,
+            $context->getRequest()
+        );
+        $entityFqcn = $controller->getEntityFqcn();
+        $entityDto = new EntityDto(
+            $entityFqcn,
+            $this->container->get(EntityFactory::class)->getEntityMetadata($entityFqcn)
+        );
         $fields = FieldCollection::new($controller->configureFields($autocompleteContext['originatingPage']));
-        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), $fields);
+        $this->container->get(EntityFactory::class)->processFields($entityDto, $fields);
         /** @var FieldDto|null $field */
         $field = $fields->getByProperty($autocompleteContext['propertyName']);
         /** @var \Closure|null $queryBuilderCallable */


### PR DESCRIPTION
Currently the autocomplete does not process fields, if you have a FieldConfigurator that modifies a custom option like AssociationField::OPTION_QUERY_BUILDER_CALLABLE it is not applied.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
